### PR TITLE
Adicionado BSides SPv14

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 * [The Developers Conference (TDC)](http://www.thedevelopersconference.com.br/) | **May 03-06** | Florianópolis
 * [CEJS 2017](http://www.cejs.com.br/) | **May 13** | Fortaleza
 * [Simpósio Brasileiro de Redes de Computadores e Sistemas Distribuídos (SBRC)](http://sbrc2017.ufpa.br/) | **May 15-19** | Belém
-* [Security BSides SPv14)](https://www.facebook.com/events/1790032051324595/) | **May 20-21** | Sao Paulo
+* [Security BSides SPv14](https://www.facebook.com/events/1790032051324595/) | **May 20-21** | Sao Paulo
 
 #### June
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 * [The Developers Conference (TDC)](http://www.thedevelopersconference.com.br/) | **May 03-06** | Florianópolis
 * [CEJS 2017](http://www.cejs.com.br/) | **May 13** | Fortaleza
 * [Simpósio Brasileiro de Redes de Computadores e Sistemas Distribuídos (SBRC)](http://sbrc2017.ufpa.br/) | **May 15-19** | Belém
+* [Security BSides SPv14)](https://www.facebook.com/events/1790032051324595/) | **May 20-21** | Sao Paulo
 
 #### June
 


### PR DESCRIPTION
A Conferência Security BSides São Paulo (BSidesSP) é um evento gratuito sobre segurança da informação e cultura hacker, que será realizado na PUC em São Paulo, Brasil, nos dias 20 e 21 de Maio de 2017.